### PR TITLE
Use trixie-slim image for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,12 @@
-FROM ubuntu:20.04
+FROM debian:trixie-slim
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /opt
 
 RUN apt update && apt install -y \
-    gcc \
-    python3 \
-    python3-pip \
-    libcups2-dev \
-    python3-dev \ 
-    python3-libxml2 \
+    python3-cups \
+    python3-lxml \
 && rm -rf /var/lib/apt/lists/*
-
-RUN pip3 install \
-	pycups==2.0.1
 
 COPY . ./
 
-ENTRYPOINT ["./airprint-generate.py"]
+ENTRYPOINT ["python3", "airprint-generate.py"]


### PR DESCRIPTION
Though this change isn't strictly necessary, use of the Debian `trixie-slim` image cuts down on size and simplifies the `Dockerfile`.